### PR TITLE
refactor: Migrate from GHC.Prim/GHC.Word to standard imports

### DIFF
--- a/bits-extra.cabal
+++ b/bits-extra.cabal
@@ -31,7 +31,6 @@ common base                       { build-depends: base                       >=
 common criterion                  { build-depends: criterion                  >= 1.3        && < 1.7    }
 common doctest                    { build-depends: doctest                    >= 0.16.2     && < 0.25   }
 common doctest-discover           { build-depends: doctest-discover           >= 0.2        && < 0.3    }
-common ghc-prim                   { build-depends: ghc-prim                   >= 0.5        && < 0.14   }
 common hedgehog                   { build-depends: hedgehog                   >= 0.5.3      && < 1.6    }
 common hspec                      { build-depends: hspec                      >= 2.4        && < 3      }
 common hw-hedgehog                { build-depends: hw-hedgehog                >= 0.1        && < 0.2    }
@@ -41,7 +40,7 @@ common vector                     { build-depends: vector                     >=
 common config
   default-language:     Haskell2010
   ghc-options:          -Wall
-  if (flag(bmi2)) && (impl(ghc >= 8.4.1))
+  if flag(bmi2)
     ghc-options:        -mbmi2 -msse4.2
     cpp-options:        -DBMI2_ENABLED
 
@@ -50,7 +49,6 @@ common bits-extra
 
 library
   import:               base, config
-                      , ghc-prim
                       , vector
   hs-source-dirs:       src
   ghc-options:          -O2
@@ -66,7 +64,6 @@ library
 
 test-suite bits-extra-test
   import:               base, config
-                      , ghc-prim
                       , hedgehog
                       , hspec
                       , hw-hedgehog
@@ -85,7 +82,6 @@ test-suite bits-extra-test
 benchmark bench
   import:               base, config
                       , criterion
-                      , ghc-prim
                       , vector
   type:                 exitcode-stdio-1.0
   main-is:              Main.hs

--- a/src/Data/Bits/Pdep/Prim.hs
+++ b/src/Data/Bits/Pdep/Prim.hs
@@ -19,10 +19,10 @@ module Data.Bits.Pdep.Prim
   , fastPdepEnabled
   ) where
 
-import GHC.Prim
-import GHC.Word
+import Data.Word
 
 #if MIN_VERSION_base(4,11,0) && defined(BMI2_ENABLED)
+import GHC.Exts
 #else
 import Data.Bits.Pdep.Slow
 #endif

--- a/src/Data/Bits/Pext/Prim.hs
+++ b/src/Data/Bits/Pext/Prim.hs
@@ -19,10 +19,10 @@ module Data.Bits.Pext.Prim
   , fastPextEnabled
   ) where
 
-import GHC.Word
+import Data.Word
 
 #if MIN_VERSION_base(4,11,0) && defined(BMI2_ENABLED)
-import GHC.Prim
+import GHC.Exts
 #else
 import Data.Bits.Pext.Slow
 #endif


### PR DESCRIPTION
## Description
This PR modernizes the import structure by migrating from GHC internal modules (`GHC.Prim`, `GHC.Word`) to their standard library equivalents (`GHC.Exts`, `Data.Word`). This change improves compatibility, reduces dependency on GHC internals, and removes the explicit `ghc-prim` package dependency while maintaining full functionality across all build configurations.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

### Import Modernization
- **Replaced `GHC.Word` with `Data.Word`** in both `src/Data/Bits/Pdep/Prim.hs` and `src/Data/Bits/Pext/Prim.hs` for standard Word type imports
- **Replaced `GHC.Prim` with `GHC.Exts`** in BMI2-enabled code paths (`src/Data/Bits/Pext/Prim.hs`)
- `GHC.Exts` re-exports the necessary primitives from both `GHC.Prim` and `GHC.Word`, providing a cleaner unified interface

### Dependency Cleanup
- **Removed `ghc-prim` dependency** from `bits-extra.cabal`:
  - Removed from library build-depends
  - Removed from test-suite build-depends
  - Removed from benchmark build-depends
  - Removed common `ghc-prim` section entirely

### Build Configuration Simplification
- **Simplified conditional compilation flag** in cabal file from `if (flag(bmi2)) && (impl(ghc >= 8.4.1))` to `if flag(bmi2)`
- Removed GHC version constraint as BMI2 functionality is now accessed through the standard `GHC.Exts` module available in all supported GHC versions

## Testing
- [x] All existing tests pass
- [ ] New tests added for new functionality (N/A - refactoring only)
- [x] Manual testing performed

## Additional Notes

**Motivation**: This refactoring reduces the direct dependency on GHC's internal primitive modules, making the codebase more maintainable and less susceptible to changes in GHC's internal structure. The `GHC.Exts` module provides a stable interface for accessing GHC extensions and primitives that's part of the base library.

**Compatibility**: The changes maintain full backward compatibility as `GHC.Exts` re-exports all necessary types and functions from `GHC.Prim` and `GHC.Word`. The functionality remains identical while the import structure is cleaner and more idiomatic.

**Impact**: This is a pure refactoring with no functional changes—all primitive operations and Word types remain available through the new import paths. The removal of `ghc-prim` as an explicit dependency simplifies the package's dependency tree.